### PR TITLE
Make 'connectors' module public for access to type information

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ extern crate embedded_hal;
 use embedded_hal::blocking::spi::Write;
 use embedded_hal::digital::v2::OutputPin;
 
-mod connectors;
+pub mod connectors;
 use connectors::*;
 
 /// Maximum number of displays connected in series supported by this lib.
@@ -316,7 +316,7 @@ where
     /// Construct a new MAX7219 driver instance from pre-existing SPI in full hardware mode.
     /// The SPI will control CS (LOAD) line according to it's internal mode set.
     /// If you need the CS line to be controlled manually use MAX7219::from_spi_cs
-    /// 
+    ///
     /// * `NOTE` - make sure the SPI is initialized in MODE_0 with max 10 Mhz frequency.
     ///
     /// # Arguments
@@ -345,7 +345,7 @@ where
     /// Construct a new MAX7219 driver instance from pre-existing SPI and CS pin
     /// set to output. This version of the connection uses the CS pin manually
     /// to avoid issues with how the CS mode is handled in hardware SPI implementations.
-    /// 
+    ///
     /// * `NOTE` - make sure the SPI is initialized in MODE_0 with max 10 Mhz frequency.
     ///
     /// # Arguments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,34 @@ where
         Ok(())
     }
 
+
+    ///
+    /// Writes a raw value to the display
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - display to address as connected in series (0 -> last)
+    /// * `raw` - an array of raw bytes to write. Each bit represents a pixel on the display
+    ///
+    /// # Errors
+    ///
+    /// * `PinError` - returned in case there was an error setting a PIN on the device
+    ///
+    pub fn write_raw(&mut self, addr: usize, raw: &[u8; MAX_DIGITS]) -> Result<(), PinError> {
+        let prev_dm = self.decode_mode;
+        self.set_decode_mode(0, DecodeMode::NoDecode)?;
+
+        let mut digit: u8 = 0;
+        for b in raw {
+            self.c.write_raw(addr, digit, *b)?;
+            digit += 1;
+        }
+
+        self.set_decode_mode(0, prev_dm)?;
+
+        Ok(())
+    }
+
     ///
     /// Set test mode on/off
     ///


### PR DESCRIPTION
First of all, thanks for your work on updating this sensor driver to use the latest digital traits. Very handy!

I was wondering if it would be at all possible to make the `connectors` module contained in this library public? Specifically, I want to be able to return an instantiation of the `MAX7219` sensor from a function (and perhaps even store it in a struct - although I'm not there yet). For example:
```rs
fn initialise() -> MAX7219<PinConnector<PA6<PullNone, AltFn<AF5, PushPull, LowSpeed>>, PA4<PullNone, AltFn<AF5, PushPull, LowSpeed>>, PA5<PullNone, AltFn<AF5, PushPull, LowSpeed>>>> {
...
}
```
Right now, as the `connectors` module is private so I do not have access to the `PinConnector` type. Was there a specific reason why you wanted to keep this private? If so, any suggestions on how to solve my aforementioned problem would be greatly appreciated.

Thanks again! 