### PR TITLE
Fix addressing bug in write_raw method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@ where
         let prev_dm = self.decode_mode;
         self.set_decode_mode(0, DecodeMode::NoDecode)?;
 
-        let mut digit: u8 = 0;
+        let mut digit: u8 = 1;
         for b in raw {
             self.c.write_raw(addr, digit, *b)?;
             digit += 1;


### PR DESCRIPTION
So sorry, but I realised I introduced an addressing bug in the last Pull Request. With this fix, callers will now be able to write raw data into the 8th row.