### PR TITLE
feat: write raw byte.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 0.4.2
+
+Add `write_raw_byte` to update display in smallest possible increment.
+
 ### 0.4.1
 
 Fix edge cases for integer and buffer size for righ justification 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,13 +285,34 @@ where
 
         let mut digit: u8 = 1;
         for b in raw {
-            self.c.write_raw(addr, digit, *b)?;
+            self.write_raw_byte(addr, digit, *b)?;
             digit += 1;
         }
 
         self.set_decode_mode(0, prev_dm)?;
 
         Ok(())
+    }
+
+    ///
+    /// Writes a single byte to the underlying display.  This method is very
+    /// low-level: most users will prefer to use one of the other `write_*`
+    /// methods.
+    ///
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - display to address as connected in series (0 -> last)
+    /// * `header` - the register to write the value to
+    /// * `data` - the value to write
+    ///
+    /// # Errors
+    ///
+    /// * `DataError` - returned in case there was an error during data transfer
+    ///
+
+    pub fn write_raw_byte(&mut self, addr: usize, header: u8, data: u8) -> Result<(), DataError> {
+        self.c.write_raw(addr, header, data)
     }
 
     ///


### PR DESCRIPTION
This is a simple passthrough to the method on the controller.  Most users probably won't want it, but when a max7219 is connected to a dot-matrix display and used as a display with `embedded_graphics` it may make sense to be able to address the display in the smallest possible unit.  (For instance, an efficient display updating algorithm can keep the previous state in a framebuffer and only send the commands needed to update those bytes which have changed.)

The alternative of making the connector public seems much more drastic.

Thanks for the library!